### PR TITLE
Use float setter if int setter does not exist

### DIFF
--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
@@ -29,8 +29,8 @@ public class ChartSandbox extends MirrorAnimatorSandbox {
     public void enterSandbox() {
         Log.d("ChartBox", "entering "+this);
         fillChartWithMockData();
-        sequence($(R.id.chart).animator("spanX", 0f, 1f).duration(1000),
-                $(R.id.chart).animator("spanY", 0f, 1f).duration(1000),
+        sequence($(R.id.chart).animator("spanX", 0, 1).duration(1000),
+                $(R.id.chart).animator("spanY", 0, 1).duration(1000),
                 showMarkers()
         ).start();
     }

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/AnimatorUtils.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/AnimatorUtils.java
@@ -45,8 +45,18 @@ public class AnimatorUtils {
         return sequence(context, Arrays.asList(animators));
     }
 
+    /**
+     *
+     * @param context an Android context object to be used to resolve things like interpolator
+     * @param target the target object to be animated
+     * @param property the property to be animated
+     * @param values values to be animated on
+     * @return a MirrorAnimator initialized with the "int" setter of the property if the setter exists,
+     *  otherwise, it'll try to find the "float" setter and return a MirrorAnimator based on it.
+     * @throws java.lang.IllegalArgumentException if neither "int" or "float" setters are found
+     */
     public static MirrorAnimator animator(Context context, Object target, String property, int... values) {
-        if (hasIntSetter(target, property)) {
+        if (getSetter(target, property, int.class).isPresent()) {
             ObjectAnimator animator = ObjectAnimator.ofInt(target, property, values);
             Keyframe firstFrame = Keyframe.ofInt(0, values[0]);
             Keyframe lastFrame = Keyframe.ofInt(0, values[values.length - 1]);
@@ -60,15 +70,26 @@ public class AnimatorUtils {
         }
     }
 
-    private static boolean hasIntSetter(Object target, String property) {
-        return getSetter(target, property, int.class).isPresent();
-    }
-
+    /**
+     *
+     * @param context an Android context object to be used to resolve things like interpolator
+     * @param target the target object to be animated
+     * @param property the property to be animated
+     * @param values values to be animated on
+     * @return a MirrorAnimator
+     * @throws java.lang.IllegalArgumentException if the setter for the property isn't found
+     */
     public static MirrorAnimator animator(Context context, Object target, String property, float... values) {
-        ObjectAnimator animator = ObjectAnimator.ofFloat(target, property, values);
-        Keyframe firstFrame = Keyframe.ofFloat(0, values[0]);
-        Keyframe lastFrame = Keyframe.ofFloat(0, values[values.length - 1]);
-        return new MirrorObjectAnimator(context, animator, firstFrame, lastFrame);
+        if (getSetter(target, property, float.class).isPresent()) {
+            ObjectAnimator animator = ObjectAnimator.ofFloat(target, property, values);
+            Keyframe firstFrame = Keyframe.ofFloat(0, values[0]);
+            Keyframe lastFrame = Keyframe.ofFloat(0, values[values.length - 1]);
+            return new MirrorObjectAnimator(context, animator, firstFrame, lastFrame);
+        } else {
+            String msg = String.format("Cannot create animator because the setter for %s(float) doesn't exist or not public.",
+                    property);
+            throw new IllegalArgumentException(msg);
+        }
     }
 
     public static void setInterpolator(Context context, Animator animator, int resId) {

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/AnimatorUtils.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/AnimatorUtils.java
@@ -7,6 +7,9 @@ import android.content.Context;
 import android.view.animation.AnimationUtils;
 import android.view.animation.Interpolator;
 
+import com.jimulabs.util.Optional;
+
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,7 +24,7 @@ public class AnimatorUtils {
     }
 
     static synchronized long computeDuration(long duration1x) {
-        return (long) (duration1x * 1/sSpeed);
+        return (long) (duration1x * 1 / sSpeed);
     }
 
     public static MirrorAnimator together(Context context, List<MirrorAnimator> animators) {
@@ -43,21 +46,46 @@ public class AnimatorUtils {
     }
 
     public static MirrorAnimator animator(Context context, Object target, String property, int... values) {
-        ObjectAnimator animator = ObjectAnimator.ofInt(target, property, values);
-        Keyframe firstFrame = Keyframe.ofInt(0, values[0]);
-        Keyframe lastFrame = Keyframe.ofInt(0, values[values.length-1]);
-        return new MirrorObjectAnimator(context, animator, firstFrame, lastFrame);
+        if (hasIntSetter(target, property)) {
+            ObjectAnimator animator = ObjectAnimator.ofInt(target, property, values);
+            Keyframe firstFrame = Keyframe.ofInt(0, values[0]);
+            Keyframe lastFrame = Keyframe.ofInt(0, values[values.length - 1]);
+            return new MirrorObjectAnimator(context, animator, firstFrame, lastFrame);
+        } else {
+            float[] fvalues = new float[values.length];
+            for (int i = 0; i < fvalues.length; i++) {
+                fvalues[i] = values[i];
+            }
+            return animator(context, target, property, fvalues);
+        }
+    }
+
+    private static boolean hasIntSetter(Object target, String property) {
+        return getSetter(target, property, int.class).isPresent();
     }
 
     public static MirrorAnimator animator(Context context, Object target, String property, float... values) {
         ObjectAnimator animator = ObjectAnimator.ofFloat(target, property, values);
         Keyframe firstFrame = Keyframe.ofFloat(0, values[0]);
-        Keyframe lastFrame = Keyframe.ofFloat(0, values[values.length-1]);
+        Keyframe lastFrame = Keyframe.ofFloat(0, values[values.length - 1]);
         return new MirrorObjectAnimator(context, animator, firstFrame, lastFrame);
     }
 
     public static void setInterpolator(Context context, Animator animator, int resId) {
         Interpolator interpolator = AnimationUtils.loadInterpolator(context, resId);
         animator.setInterpolator(interpolator);
+    }
+
+    static Optional<Method> getSetter(Object target, String propertyName, Class paramType) {
+        String setterName = "set" + capitalizeHead(propertyName);
+        try {
+            return Optional.of(target.getClass().getMethod(setterName, paramType));
+        } catch (NoSuchMethodException e) {
+            return Optional.absent();
+        }
+    }
+
+    private static String capitalizeHead(String propertyName) {
+        return propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
     }
 }

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorAnimator.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorAnimator.java
@@ -8,6 +8,8 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.View;
 
+import com.jimulabs.util.Optional;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -165,19 +167,19 @@ public abstract class MirrorAnimator {
 
         private void callSetter(Object target, String propertyName, Keyframe firstFrame) {
             try {
-                String setterName = "set" + capitalizeHead(propertyName);
-                Method setter = target.getClass().getMethod(setterName, firstFrame.getType());
-                setter.invoke(target, firstFrame.getValue());
-                Log.d(LOG_TAG, String.format("%s=%s", propertyName, firstFrame.getValue()));
-            } catch (IllegalAccessException | NoSuchMethodException
-                    | InvocationTargetException e) {
+                Class type = firstFrame.getType();
+                Optional<Method> setter = AnimatorUtils.getSetter(target, propertyName, type);
+                if (setter.isPresent()) {
+                    setter.get().invoke(target, firstFrame.getValue());
+                    Log.d(LOG_TAG, String.format("%s=%s", propertyName, firstFrame.getValue()));
+                } else {
+                    Log.e(LOG_TAG, String.format("Setter for %s(%s) does not exist", propertyName, type));
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) {
                 Log.e(LOG_TAG, String.format("Failed to set value of \"%s\"", propertyName), e);
             }
         }
 
-        private String capitalizeHead(String propertyName) {
-            return propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
-        }
     }
 
     public interface StageSetter {

--- a/lib/src/main/java/com/jimulabs/util/Optional.java
+++ b/lib/src/main/java/com/jimulabs/util/Optional.java
@@ -1,0 +1,154 @@
+package com.jimulabs.util;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Created by matt on 2014-03-05.
+ */
+public class Optional<T> {
+
+    private final T mReference;
+    private final boolean mPresent;
+
+    // Private constructor for factory methods
+    private Optional(T reference, boolean present) {
+        mReference = reference;
+        mPresent = present;
+    }
+
+    /**
+     * Create an absent Optional with no value.
+     *
+     * @param <T> The type of the non-value
+     * @return An Optional representing this non-value
+     */
+    public static <T> Optional<T> absent() {
+        return new Optional<T>(null, false);
+    }
+
+    /**
+     * Create an Optional value with the given reference
+     *
+     * @param reference The non-null value to wrap in the Optional instance
+     * @param <T>       The type of the value
+     * @return An Optional holding the passed value
+     */
+    public static <T> Optional<T> of(T reference) {
+        if (reference == null) {
+            throw new IllegalStateException("Optional.of() must be passed a non-null reference");
+        } else {
+            return new Optional<T>(reference, true);
+        }
+    }
+
+    /**
+     * Create an Optional from a reference that may be null
+     *
+     * @param reference The value (possibly null) to create the optional from
+     * @param <T>       The type of the value
+     * @return An pOtional wrapping the value if it's non-null, or an absent Optional otherwise
+     */
+    public static <T> Optional<T> fromNullable(T reference) {
+        if (reference == null) {
+            return Optional.absent();
+        } else {
+            return Optional.of(reference);
+        }
+    }
+
+    /**
+     * @return true if the wrapped reference is present, false otherwise
+     */
+    public boolean isPresent() {
+        return mPresent;
+    }
+
+    /**
+     * @return The non-null value wrapped by this Optional
+     * @throws IllegalStateException if the Optional is absent
+     */
+    public T get() {
+        if (mPresent) {
+            return mReference;
+        } else {
+            throw new IllegalStateException("Can't get() an absent reference from Optional");
+        }
+    }
+
+    /**
+     * @return An immutable singleton set containing the reference if it is present, or an
+     * immutable empty set if it is absent
+     */
+    public Set<T> asSet() {
+        if (mPresent) {
+            return Collections.singleton(mReference);
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * @return The wrapped reference if it's present, or null if it's not
+     */
+    public T orNull() {
+        return mPresent ? mReference : null;
+    }
+
+    /**
+     * @param defaultValue
+     * @return The wrapped reference if it's present, or <code>defaultValue</code> if it's not
+     */
+    public T or(T defaultValue) {
+        return mPresent ? mReference : defaultValue;
+    }
+
+    /**
+     * @param other
+     * @return This instance if it has a value present, other <code>otherwise</code>
+     */
+    public Optional<T> or(Optional<T> other) {
+        return mPresent ? this : other;
+    }
+
+    /**
+     * Equality comparison for Optional. Note that all absent Optionals are equal regardless
+     * of type.
+     *
+     * @param other
+     * @return true if both Optionals are absent, or both have the same value present
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (!other.getClass().equals(Optional.class)) return false;
+
+        Optional<?> o = (Optional<?>) other;
+        if (mPresent) {
+            return o.isPresent() && mReference.equals(o.get());
+        } else {
+            return !o.isPresent();
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Optional:");
+        if (mPresent) {
+            sb.append("present[")
+                    .append(mReference)
+                    .append(']');
+        } else {
+            sb.append("absent");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mReference != null ? mReference.hashCode() : 0;
+        result = 31 * result + (mPresent ? 1 : 0);
+        return result;
+    }
+}


### PR DESCRIPTION
Check if `int` setter exists instead of blindly creating an "int" animator and later finding it not working at all. If the `int` setter does not exist, use `float` setter instead. If neither `int` or `float` setters are found, throw an `IllegalArgumentException`.
