### PR TITLE
Minor refactoring: change method signatures of MirrorSandbox

### DIFF
--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumDetailSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumDetailSandbox.java
@@ -49,7 +49,7 @@ public class AlbumDetailSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutInflated(View rootView) {
+    public void onLayoutDone(View rootView) {
 //        setGlobalSpeed(0.5);
         enter().start();
 //        showTitleContainer().start();

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumDetailSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumDetailSandbox.java
@@ -49,7 +49,7 @@ public class AlbumDetailSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void enterSandbox() {
+    public void onLayoutInflated(View rootView) {
 //        setGlobalSpeed(0.5);
         enter().start();
 //        showTitleContainer().start();

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumListBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumListBox.java
@@ -32,7 +32,7 @@ public class AlbumListBox extends MirrorSandboxBase {
     }
 
     @Override
-    public void onLayoutInflated(View rootView) {
+    public void onLayoutDone(View rootView) {
         List<Album> albums = new ArrayList<>();
         MockData md = new MockData();
         for (int i = 0; i < 100; i++) {

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumListBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumListBox.java
@@ -32,7 +32,7 @@ public class AlbumListBox extends MirrorSandboxBase {
     }
 
     @Override
-    public void enterSandbox() {
+    public void onLayoutInflated(View rootView) {
         List<Album> albums = new ArrayList<>();
         MockData md = new MockData();
         for (int i = 0; i < 100; i++) {

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ButterknifeBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ButterknifeBox.java
@@ -14,7 +14,7 @@ public class ButterknifeBox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutInflated(View rootView) {
+    public void onLayoutDone(View rootView) {
         ButterknifeView v = (ButterknifeView) $(R.id.butterknife).getView();
         v.setText("Yay!", "Butterknife is supported!");
     }

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ButterknifeBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ButterknifeBox.java
@@ -14,7 +14,7 @@ public class ButterknifeBox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void enterSandbox() {
+    public void onLayoutInflated(View rootView) {
         ButterknifeView v = (ButterknifeView) $(R.id.butterknife).getView();
         v.setText("Yay!", "Butterknife is supported!");
     }

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
@@ -25,7 +25,7 @@ public class ChartSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutInflated(View rootView) {
+    public void onLayoutDone(View rootView) {
         Log.d("ChartBox", "entering "+this);
         fillChartWithMockData();
         sequence($(R.id.chart).animator("spanX", 0, 1).duration(1000),

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
@@ -25,7 +25,7 @@ public class ChartSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void enterSandbox() {
+    public void onLayoutInflated(View rootView) {
         Log.d("ChartBox", "entering "+this);
         fillChartWithMockData();
         sequence($(R.id.chart).animator("spanX", 0, 1).duration(1000),
@@ -35,7 +35,7 @@ public class ChartSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void destroySandbox() {
+    public void onDestroy() {
         Log.d("ChartBox", "destroying "+this);
     }
 

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/MirrorAnimatorSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/MirrorAnimatorSandbox.java
@@ -28,7 +28,7 @@ public abstract class MirrorAnimatorSandbox extends MirrorSandboxBase {
     }
 
     @Override
-    public void destroySandbox() {
+    public void onDestroy() {
         // does nothing by default
     }
 

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/SneakPeekBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/SneakPeekBox.java
@@ -23,7 +23,7 @@ public class SneakPeekBox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutInflated(View rootView) {
+    public void onLayoutDone(View rootView) {
         fillViewsWithMockData();
         sequence($(R.id.text1).scale(0, 3, 1)
                         .interpolator(getContext(), android.R.interpolator.bounce)

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/SneakPeekBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/SneakPeekBox.java
@@ -23,7 +23,7 @@ public class SneakPeekBox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void enterSandbox() {
+    public void onLayoutInflated(View rootView) {
         fillViewsWithMockData();
         sequence($(R.id.text1).scale(0, 3, 1)
                         .interpolator(getContext(), android.R.interpolator.bounce)

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
@@ -26,7 +26,7 @@ public interface MirrorSandbox {
      * views with mock data. This method is not supposed to be called from production code.
      * @param rootView
      */
-    void onLayoutInflated(View rootView);
+    void onLayoutDone(View rootView);
 
     /**
      * Mirror calls this method from the UI thread in the Activity#onDestroy() call back.

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
@@ -1,5 +1,7 @@
 package com.jimulabs.mirrorsandbox;
 
+import android.view.View;
+
 /**
  * MirrorSandbox classes are considered "design mode" code for quick experiments or populating views
  * with mock data. Think of it as a REPL for Android UI (layouts and animations) when used in
@@ -22,12 +24,13 @@ public interface MirrorSandbox {
      *
      * This method is considered as a "design mode" used for quick experiments or populating
      * views with mock data. This method is not supposed to be called from production code.
+     * @param rootView
      */
-    void enterSandbox();
+    void onLayoutInflated(View rootView);
 
     /**
      * Mirror calls this method from the UI thread in the Activity#onDestroy() call back.
      * This method can be used to release things that are not supposed to be persist across refreshes.
      */
-    void destroySandbox();
+    void onDestroy();
 }

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandboxBase.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandboxBase.java
@@ -13,7 +13,7 @@ public abstract class MirrorSandboxBase implements MirrorSandbox {
     }
 
     @Override
-    public void destroySandbox() {
+    public void onDestroy() {
         // do nothing by default
     }
 }


### PR DESCRIPTION
Use more meaningful names of `MirrorSandbox` methods 
