### PR TITLE
Add prefix $ and onCreate to MirrorSandbox

### DIFF
--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumDetailSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumDetailSandbox.java
@@ -49,7 +49,7 @@ public class AlbumDetailSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutDone(View rootView) {
+    public void $onLayoutDone(View rootView) {
 //        setGlobalSpeed(0.5);
         enter().start();
 //        showTitleContainer().start();

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumListBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/AlbumListBox.java
@@ -32,7 +32,7 @@ public class AlbumListBox extends MirrorSandboxBase {
     }
 
     @Override
-    public void onLayoutDone(View rootView) {
+    public void $onLayoutDone(View rootView) {
         List<Album> albums = new ArrayList<>();
         MockData md = new MockData();
         for (int i = 0; i < 100; i++) {

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ButterknifeBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ButterknifeBox.java
@@ -14,7 +14,7 @@ public class ButterknifeBox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutDone(View rootView) {
+    public void $onLayoutDone(View rootView) {
         ButterknifeView v = (ButterknifeView) $(R.id.butterknife).getView();
         v.setText("Yay!", "Butterknife is supported!");
     }

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/ChartSandbox.java
@@ -25,7 +25,7 @@ public class ChartSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutDone(View rootView) {
+    public void $onLayoutDone(View rootView) {
         Log.d("ChartBox", "entering "+this);
         fillChartWithMockData();
         sequence($(R.id.chart).animator("spanX", 0, 1).duration(1000),
@@ -35,7 +35,7 @@ public class ChartSandbox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onDestroy() {
+    public void $onDestroy() {
         Log.d("ChartBox", "destroying "+this);
     }
 

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/MirrorAnimatorSandbox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/MirrorAnimatorSandbox.java
@@ -28,7 +28,7 @@ public abstract class MirrorAnimatorSandbox extends MirrorSandboxBase {
     }
 
     @Override
-    public void onDestroy() {
+    public void $onDestroy() {
         // does nothing by default
     }
 

--- a/examples/src/main/java/com/jimulabs/googlemusicmock/box/SneakPeekBox.java
+++ b/examples/src/main/java/com/jimulabs/googlemusicmock/box/SneakPeekBox.java
@@ -23,7 +23,7 @@ public class SneakPeekBox extends MirrorAnimatorSandbox {
     }
 
     @Override
-    public void onLayoutDone(View rootView) {
+    public void $onLayoutDone(View rootView) {
         fillViewsWithMockData();
         sequence($(R.id.text1).scale(0, 3, 1)
                         .interpolator(getContext(), android.R.interpolator.bounce)

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
@@ -6,31 +6,46 @@ import android.view.View;
  * MirrorSandbox classes are considered "design mode" code for quick experiments or populating views
  * with mock data. Think of it as a REPL for Android UI (layouts and animations) when used in
  * combination with the Java code hot-swapping of Mirror.
- *
+ * <p/>
  * Mirror uses classes that implement this interface and set the "sandbox" attribute of
  * a mirror screen file:
- *
+ * <p/>
  * &lt;screen sandbox="foo.bar.BarBox"&gt;
- *
+ * <p/>
  * In most cases, you can subclass {@link com.jimulabs.mirrorsandbox.MirrorSandboxBase} which
  * provides some base implementations.
- *
+ * <p/>
  * Created by lintonye on 2014-12-23.
  */
 public interface MirrorSandbox {
     /**
+     * Mirror calls this method from the UI thread right after the sandbox object is created, BEFORE
+     * the layout pass is done.
+     * <p/>
+     * Methods with the prefix '$' are considered as "design mode" methods used for quick experiments
+     * or populating views with mock data. Do not call from production code.
+     *
+     * @param rootView the root view that can be used to find child views in the layout
+     */
+    void $onCreate(View rootView);
+
+    /**
      * Mirror calls this method from the UI thread after the layout pass for the entire screen finishes.
      * Methods such as View#getMeasuredWidth() will return proper values.
+     * <p/>
+     * Methods with the prefix '$' are considered as "design mode" methods used for quick experiments
+     * or populating views with mock data. Do not call from production code.
      *
-     * This method is considered as a "design mode" used for quick experiments or populating
-     * views with mock data. This method is not supposed to be called from production code.
-     * @param rootView
+     * @param rootView the root view that can be used to find child views in the layout
      */
-    void onLayoutDone(View rootView);
+    void $onLayoutDone(View rootView);
 
     /**
      * Mirror calls this method from the UI thread in the Activity#onDestroy() call back.
      * This method can be used to release things that are not supposed to be persist across refreshes.
+     * <p/>
+     * Methods with the prefix '$' are considered as "design mode" methods used for quick experiments
+     * or populating views with mock data. Do not call from production code.
      */
-    void onDestroy();
+    void $onDestroy();
 }

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandbox.java
@@ -20,10 +20,12 @@ import android.view.View;
 public interface MirrorSandbox {
     /**
      * Mirror calls this method from the UI thread right after the sandbox object is created, BEFORE
-     * the layout pass is done.
+     * the layout pass is done. This method can be used for sandbox-only initialization code.
      * <p/>
      * Methods with the prefix '$' are considered as "design mode" methods used for quick experiments
-     * or populating views with mock data. Do not call from production code.
+     * or populating views with mock data. Do not call from production code. However, it is encouraged
+     * to call other methods in the sandbox class from production code to reuse the code written in
+     * sandbox mode.
      *
      * @param rootView the root view that can be used to find child views in the layout
      */
@@ -34,7 +36,9 @@ public interface MirrorSandbox {
      * Methods such as View#getMeasuredWidth() will return proper values.
      * <p/>
      * Methods with the prefix '$' are considered as "design mode" methods used for quick experiments
-     * or populating views with mock data. Do not call from production code.
+     * or populating views with mock data. Do not call from production code. However, it is encouraged
+     * to call other methods in the sandbox class from production code to reuse the code written in
+     * sandbox mode.
      *
      * @param rootView the root view that can be used to find child views in the layout
      */
@@ -45,7 +49,9 @@ public interface MirrorSandbox {
      * This method can be used to release things that are not supposed to be persist across refreshes.
      * <p/>
      * Methods with the prefix '$' are considered as "design mode" methods used for quick experiments
-     * or populating views with mock data. Do not call from production code.
+     * or populating views with mock data. Do not call from production code. However, it is encouraged
+     * to call other methods in the sandbox class from production code to reuse the code written in
+     * sandbox mode.
      */
     void $onDestroy();
 }

--- a/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandboxBase.java
+++ b/lib/src/main/java/com/jimulabs/mirrorsandbox/MirrorSandboxBase.java
@@ -13,7 +13,12 @@ public abstract class MirrorSandboxBase implements MirrorSandbox {
     }
 
     @Override
-    public void onDestroy() {
+    public void $onCreate(View rootView) {
+        // do nothing by default
+    }
+
+    @Override
+    public void $onDestroy() {
         // do nothing by default
     }
 }


### PR DESCRIPTION
- Add `$` prefix to `MirrorSandbox` methods to indicate that these methods are not supposed to be called from production code. However, it is encouraged to call other methods from production code to reuse the code written in sandbox mode.
- Add `$onCreate()` method for sandbox-only initialization code
