### PR TITLE
remove android:allowBackup="true" from manifest

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     compile 'com.jakewharton:butterknife:6.0.0'
     compile 'com.squareup.picasso:picasso:2.5.0'
 
-    // compile 'com.jimulabs.mirrorsandbox:mirror-sandbox:0.1.+'
+//    compile 'com.jimulabs.mirrorsandbox:mirror-sandbox:0.1.+'
     compile project(':lib')
 
-    compile 'com.jimulabs.motionkit:motion-kit:0.1.0-SNAPSHOT@aar'
+    compile 'com.jimulabs.motionkit:motion-kit:0.1.0'
 }

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.jimulabs.mirrorsandbox">
 
-    <application android:allowBackup="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Currently, the AndroidManifest contains `android:allowBackup="true"`. We should remove this attribute as it is not something a library project should decide and it causes the mergeManifest to fail on projects that requires `android:allowBackup="false"`.

Usually, using `tools:replace="android:allowBackup"` in the Manifest of the main project should fix issue, but `replace` doesn't currently work with `allowBackup`. See https://code.google.com/p/android/issues/detail?id=70073.

Looks like the best thing to do is just to remove it from library manifest. 

WalkAround: import the library manually and remove the attribute.
